### PR TITLE
Add `jump_into` to bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Dunno. Seems broken.
 
 Used by audit maybe?
 
+### `jump_into`
+
+This wapper is designed to allow the user to ssh into a node that the user has a job running on. Created because sshing into mahuika nodes sometimes does not work. Designed based on `srun --pty --overlap --jobid "$jobid" -w "$target_node" bash`. 
+
 ### `jupyterbash`
 
 Used by jupyter for something.

--- a/jump_into
+++ b/jump_into
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  jump_into JOBID [NODE]
+
+Examples:
+  jump_into 123456
+  jump_into 123456 node02
+EOF
+}
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || err "Required command not found: $1"
+}
+
+main() {
+  [[ $# -ge 1 && $# -le 2 ]] || { usage; exit 2; }
+
+  local jobid="$1"
+  local target_node="${2:-}"
+
+  need_cmd squeue
+  need_cmd scontrol
+  need_cmd srun
+  need_cmd awk
+
+  # Get compressed nodelist from squeue
+  local nodelist
+  nodelist="$(squeue -j "$jobid" -h -o "%N" | awk 'NR==1{print $1}')"
+  [[ -n "${nodelist:-}" && "$nodelist" != "(null)" ]] \
+    || err "Could not determine NodeList for jobid=$jobid"
+
+  # Expand to hostnames (This is helpful to have if the hostname ever changes for nodes GRW)
+  local nodes
+  nodes="$(scontrol show hostnames "$nodelist")"
+  [[ -n "${nodes:-}" ]] || err "Failed to expand NodeList: $nodelist"
+
+  # Default to first node if none specified
+  if [[ -z "$target_node" ]]; then
+    target_node="$(echo "$nodes" | awk 'NR==1{print $1}')"
+  else
+    # Ensure requested node is in allocation
+    echo "$nodes" | awk -v t="$target_node" '$1==t{found=1} END{exit !found}' \
+      || err "Requested node '$target_node' is not in job allocation"
+  fi
+
+  echo "Jumping into node: $target_node (job $jobid)"
+  exec srun --pty --overlap --jobid "$jobid" -w "$target_node" bash
+}
+
+main "$@"


### PR DESCRIPTION
This wapper is designed to allow the user to ssh into a node that the user has a job running on. Created because sshing into mahuika nodes sometimes does not work. Designed based on `srun --pty --overlap --jobid "$jobid" -w "$target_node" bash`. 
